### PR TITLE
change var name id to _id and api_versions['lol-status'] from '1.0' to 1.0

### DIFF
--- a/riotwatcher.py
+++ b/riotwatcher.py
@@ -117,7 +117,7 @@ api_versions = {
     'game': 1.3,
     'league': 2.5,
     'lol-static-data': 1.2,
-    'lol-status': '1.0',
+    'lol-status': 1.0,
     'match': 2.2,
     'matchhistory': 2.2,
     'stats': 1.3,


### PR DESCRIPTION
`id` change just because I don't like having built-ins as variable names.

Other change for consistency.
