### PR TITLE
RiotWatcher.get_summoner() fix

### DIFF
--- a/riotwatcher.py
+++ b/riotwatcher.py
@@ -507,7 +507,7 @@ class RiotWatcher:
     def get_summoner(self, name=None, _id=None, region=None):
         if (name is None) != (_id is None):
             if name is not None:
-                return self.get_summoners(names=[name, ], region=region)[name]
+                return self.get_summoners(names=[name, ], region=region)[name.replace(" ",'').lower()]
             else:
                 return self.get_summoners(ids=[_id, ], region=region)[str(_id)]
         return None


### PR DESCRIPTION
Since get_summoner relies on get_summoners output, it failed when the literal name was used to index into the returned dictionary. The dictionary returned by get_summoners lowered the input name and removed spaces. I just added a string replace to remove spaces and lowered the text. 

No clue how more exotic characters interact with the api but this should fix some of the more minor ones.
