### PR TITLE
Fixes issue #19 with importing classes in Python3.4.

### DIFF
--- a/riotwatcher/__init__.py
+++ b/riotwatcher/__init__.py
@@ -1,3 +1,3 @@
-from riotwatcher import *
+from .riotwatcher import *
 
 __all__ = ['riotwatcher']


### PR DESCRIPTION
Seems like using from riotwatcher import * in the init was only importing the riotwatcher project directory. This fixes it by using a relative path.