### PR TITLE
Fixing encoding issue for Python3 installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,4 +287,4 @@ Attribution
 
 RiotWatcher isn't endorsed by Riot Games and doesn't reflect the views or opinions of Riot Games or anyone officially
 involved in producing or managing *League of Legends*. *League of Legends* and Riot Games are trademarks or registered
-trademarks of Riot Games, Inc. *League of Legends* © Riot Games, Inc.
+trademarks of Riot Games, Inc. *League of Legends* (c) Riot Games, Inc.


### PR DESCRIPTION
While attempting to install the library in python3 by running
`python3 setup.py install`, the script crash while reading the Riot API
official licence (because of the copyright character). This fix simply
use the `(c)` instead of the copyright character.