### PR TITLE
Add participant identification in normal matches

### DIFF
--- a/riotwatcher/__init__.py
+++ b/riotwatcher/__init__.py
@@ -1,4 +1,4 @@
-from .RiotWatcher import RiotWatcher
+from .riotwatcher import RiotWatcher
 
 __all__ = [
     'RiotWatcher',

--- a/riotwatcher/_apis/MatchApiV3.py
+++ b/riotwatcher/_apis/MatchApiV3.py
@@ -15,19 +15,28 @@ class MatchApiV3(NamedEndpoint):
         """
         super(MatchApiV3, self).__init__(base_api, MatchApiV3.__name__)
 
-    def by_id(self, region, match_id):
+    def by_id(
+            self,
+            region,
+            match_id,
+            for_account_id=None,
+            for_platform_id=None):
         """
         Get match by match ID
 
-        :param string region: The region to execute this request on
-        :param long match_id: The match ID.
+        :param string region:           The region to execute this request on
+        :param long match_id:           The match ID.
+        :param long for_account_id:     Used to identify the participant to be unobfuscated
+        :param string for_platform_id:  Used to identify the participant to be unobfuscated
 
         :returns: MatchDto
         """
         return self._request(
             self.by_id.__name__,
             region,
-            '/lol/match/v3/matches/{matchId}'.format(matchId=match_id)
+            '/lol/match/v3/matches/{matchId}'.format(matchId=match_id),
+            forAccountId=for_account_id,
+            forPlatformId=for_platform_id
         )
 
     def matchlist_by_account(


### PR DESCRIPTION
This allows for the given participant to be unobfuscated by passing in their account ID.

Hopefully I didn't screw anything up - it's my first pull request