### PR TITLE
Add runesReforged to DataDragon api

### DIFF
--- a/src/riotwatcher/_apis/DataDragonApi.py
+++ b/src/riotwatcher/_apis/DataDragonApi.py
@@ -41,6 +41,11 @@ class DataDragonApi:
         url_ext = 'rune'
 
         return self._request(version, url_ext, locale)
+    
+    def runes_reforged(self, version, locale=None):
+        url_ext = 'runesReforged'
+        
+        return self._request(version, url_ext, locale)
 
     def summoner_spells(self, version, locale=None):
         url_ext = 'summoner'

--- a/tests/_apis/test_DataDragonApi.py
+++ b/tests/_apis/test_DataDragonApi.py
@@ -169,6 +169,26 @@ class TestDataDragonApi(object):
         )
 
         assert ret is expected_return
+        
+    def test_runes_reforged(self):
+        mock_base_api = MagicMock()
+        expected_return = object()
+        mock_base_api.request_static.return_value = expected_return
+
+        static_data = DataDragonApi(mock_base_api)
+
+        version = '234'
+        locale = 'sdfasdf'
+
+        ret = static_data.runes_reforged(version, locale)
+
+        mock_base_api.request_static.assert_called_once_with(
+            version,
+            locale,
+            'runesReforged'
+        )
+
+        assert ret is expected_return
 
     def test_summoner_spells(self):
         mock_base_api = MagicMock()


### PR DESCRIPTION
The current version of the DataDragon api doesn't have the runeReforged endpoint. This naively adds it.

Some version checking might be nice (so that runesReforged aren't requested on a version where they don't exist) but since these queries don't count against the rate limit and an error in such a case is returned anyway _caveat emptor_ is probably sufficient