### PR TITLE
Use the module logger instead of the root logger

### DIFF
--- a/src/riotwatcher/Handlers/DeprecationHandler.py
+++ b/src/riotwatcher/Handlers/DeprecationHandler.py
@@ -1,4 +1,5 @@
 import logging
+
 log = logging.getLogger(__name__)
 
 from datetime import datetime

--- a/src/riotwatcher/Handlers/DeprecationHandler.py
+++ b/src/riotwatcher/Handlers/DeprecationHandler.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from datetime import datetime
 
@@ -22,7 +23,7 @@ class DeprecationHandler(RequestHandler):
             if key not in self._warned:
                 # technically race condition here, but worst case is we double log a warning
                 self._warned.add(key)
-                logging.warning(
+                log.warning(
                     "Method %s has been deprecated by Riot! It will no longer work after %s",
                     key,
                     deprecation,

--- a/src/riotwatcher/Handlers/RateLimit/HeaderBasedLimiter.py
+++ b/src/riotwatcher/Handlers/RateLimit/HeaderBasedLimiter.py
@@ -1,4 +1,5 @@
 import logging
+
 log = logging.getLogger(__name__)
 
 import threading

--- a/src/riotwatcher/Handlers/RateLimit/HeaderBasedLimiter.py
+++ b/src/riotwatcher/Handlers/RateLimit/HeaderBasedLimiter.py
@@ -1,4 +1,6 @@
 import logging
+log = logging.getLogger(__name__)
+
 import threading
 
 from .Limits import LimitCollection, RawLimit
@@ -55,7 +57,7 @@ class HeaderBasedLimiter(object):
             return None
 
         if len(limits) != len(counts):
-            logging.warning(
+            log.warning(
                 'header "%s" and "%s" have different sizes!',
                 self._limit_header,
                 self._count_header,
@@ -65,7 +67,7 @@ class HeaderBasedLimiter(object):
 
         for limit in combined_limits:
             if limit[0][1] != limit[1][1]:
-                logging.warning(
+                log.warning(
                     'seems that limits for headers "%s" and "%s" did not match up correctly! '
                     + 'There may be issues in rate limiting. Headers were: "%s", "%s"'
                     + 'Limits from "%s" will be used.',

--- a/src/riotwatcher/Handlers/RateLimit/Limits.py
+++ b/src/riotwatcher/Handlers/RateLimit/Limits.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+
 log = logging.getLogger(__name__)
 
 import threading

--- a/src/riotwatcher/Handlers/RateLimit/Limits.py
+++ b/src/riotwatcher/Handlers/RateLimit/Limits.py
@@ -1,5 +1,7 @@
 import datetime
 import logging
+log = logging.getLogger(__name__)
+
 import threading
 
 from collections import namedtuple
@@ -68,14 +70,14 @@ class Limit(object):
                     and self._raw_limit.limit == 0
                     and self._raw_limit.count == 0
                 ):
-                    logging.warning(
+                    log.warning(
                         "overwriting time limit, previously %s, now %s. This may cause rate limitting issues.",
                         self._raw_limit.time,
                         raw_limit.time,
                     )
 
             if self._raw_limit.limit != raw_limit.limit:
-                logging.info(
+                log.info(
                     "rate limit changed from %s/%ss to %s/%ss",
                     self._raw_limit.limit,
                     self._raw_limit.time,

--- a/src/riotwatcher/Handlers/RateLimit/OopsRateLimiter.py
+++ b/src/riotwatcher/Handlers/RateLimit/OopsRateLimiter.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+
 log = logging.getLogger(__name__)
 
 

--- a/src/riotwatcher/Handlers/RateLimit/OopsRateLimiter.py
+++ b/src/riotwatcher/Handlers/RateLimit/OopsRateLimiter.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+log = logging.getLogger(__name__)
 
 
 class OopsRateLimiter(object):
@@ -24,7 +25,7 @@ class OopsRateLimiter(object):
             limit_type = response.headers.get("X-Rate-Limit-Type")
 
             if retry_after is not None:
-                logging.info(
+                log.info(
                     'hit 429 from "%s" limit! retrying after %s seconds',
                     limit_type,
                     retry_after,
@@ -33,6 +34,6 @@ class OopsRateLimiter(object):
                     seconds=int(retry_after)
                 )
             else:
-                logging.info(
+                log.info(
                     'hit 429 from "%s" limit! no retry after header...', limit_type
                 )

--- a/src/riotwatcher/Handlers/RateLimit/RateLimitHandler.py
+++ b/src/riotwatcher/Handlers/RateLimit/RateLimitHandler.py
@@ -1,5 +1,7 @@
 import datetime
 import logging
+log = logging.getLogger(__name__)
+
 import time
 
 from .. import RequestHandler
@@ -44,7 +46,7 @@ class RateLimitHandler(RequestHandler):
         if wait_until[0] is not None and wait_until[0] > datetime.datetime.now():
             to_wait = wait_until[0] - datetime.datetime.now()
 
-            logging.info(
+            log.info(
                 "waiting for %s seconds due to %s limit...",
                 to_wait.total_seconds(),
                 wait_until[1],

--- a/src/riotwatcher/Handlers/RateLimit/RateLimitHandler.py
+++ b/src/riotwatcher/Handlers/RateLimit/RateLimitHandler.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+
 log = logging.getLogger(__name__)
 
 import time

--- a/src/riotwatcher/Handlers/WaitingRateLimitHandler.py
+++ b/src/riotwatcher/Handlers/WaitingRateLimitHandler.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from riotwatcher.Handlers.RateLimit import RateLimitHandler
 
@@ -6,7 +7,7 @@ from riotwatcher.Handlers.RateLimit import RateLimitHandler
 class WaitingRateLimitHandler(RateLimitHandler):
     def __init__(self):
         super(WaitingRateLimitHandler, self).__init__()
-        logging.warning(
+        log.warning(
             "class WaitingRateLimitHandler is deprecated! "
             + "please use riotwatcher.Handlers.RateLimit.RateLimitHandler."
         )

--- a/src/riotwatcher/Handlers/WaitingRateLimitHandler.py
+++ b/src/riotwatcher/Handlers/WaitingRateLimitHandler.py
@@ -1,4 +1,5 @@
 import logging
+
 log = logging.getLogger(__name__)
 
 from riotwatcher.Handlers.RateLimit import RateLimitHandler


### PR DESCRIPTION
While developing [a package](https://github.com/Steffo99/royalpack) that uses `riotwatcher`, I noticed that `riotwatcher` was logging to the `root` logger instead of the `riotwatcher` logger.

It is [a good practice](https://docs.python.org/3.8/library/logging.html#logger-objects) to log on the module logger `logging.getLogger(__name__)` instead of the root logger `logging.root`.

Having noticed that, I fixed it for you! 😄 

In every file that uses logging, I created a module logger with `log = logging.getLogger(__name__)`.
Then, I replaced all `logging.info(message)` calls with `log.info(message)` calls.

This way, packages that use `riotwatcher` can choose what to do with its logs (display only messages above a certain level, write them to a file, etc...).