### PR TITLE
Added queues from Data Dragon json

### DIFF
--- a/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
+++ b/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
@@ -47,3 +47,6 @@ class DataDragonApi:
     def _request(self, endpoint: Endpoint, version: str, locale: str):
         url, query = endpoint(version=version, locale=locale if locale else "en_US")
         return self._base_api.raw_request_static(url, query)
+
+    def queues(self, version: str, locale: str = None):
+        return self._request(DataDragonUrls.maps, version, locale)

--- a/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
+++ b/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
@@ -49,4 +49,4 @@ class DataDragonApi:
         return self._base_api.raw_request_static(url, query)
 
     def queues(self, version: str, locale: str = None):
-        return self._request(DataDragonUrls.maps, version, locale)
+        return self._request(DataDragonUrls.queues, version, locale)

--- a/src/riotwatcher/_apis/league_of_legends/urls/DataDragonUrls.py
+++ b/src/riotwatcher/_apis/league_of_legends/urls/DataDragonUrls.py
@@ -25,3 +25,4 @@ class DataDragonUrls:
     runes_reforged = DDragonVersionLocaleEndpoint("/runesReforged.json")
     summoner_spells = DDragonVersionLocaleEndpoint("/summoner.json")
     versions = DataDragonEndpoint("/realms/{region}.json")
+    queues = DataDragonEndpoint("/queues.json")


### PR DESCRIPTION
**'Queue ids show up in several places throughout the API and are used to indicate which kind of match was played. A full list of queue ids can be found in the file below.'**

I don't know why this wasn't implemented before, but I added it
[http://static.developer.riotgames.com/docs/lol/queues.json](http://static.developer.riotgames.com/docs/lol/queues.json)