### PR TITLE
Added a single if statement, so .version_for_region requests can use the same region vars as the other requests

### DIFF
--- a/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
+++ b/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
@@ -41,6 +41,8 @@ class DataDragonApi:
 
     def versions_for_region(self, region: str):
         region = re.sub(r"\d", "", region)
+        if(region == "eun" or region == "oc"):
+            region += "e"
         url, query = DataDragonUrls.versions(region=region)
         return self._base_api.raw_request_static(url, query)
 


### PR DESCRIPTION
Added two lines so you can use "eun1" and "oc1" for datadragon .versions_for_region requests too (it uses "eune" instead of "eun1", same with "oc1"/"oce", not like the other ones)