### PR TITLE
add support new league api of TFT API

### DIFF
--- a/src/riotwatcher/_apis/team_fight_tactics/LeagueApi.py
+++ b/src/riotwatcher/_apis/team_fight_tactics/LeagueApi.py
@@ -84,3 +84,16 @@ class LeagueApi(NamedEndpoint):
         return self._request_endpoint(
             self.master.__name__, region, LeagueApiUrls.master
         )
+
+    def rated_ladders(self, region: str, queue: str):
+        """
+        Get the top rated ladders 
+
+        :returns: TopRatedLadderEntryDto
+        """
+        return self._request_endpoint(
+            self.rated_ladders.__name__,
+            region,
+            LeagueApiUrls.rated_ladders,
+            queue=queue,
+        )

--- a/src/riotwatcher/_apis/team_fight_tactics/urls/LeagueApiUrls.py
+++ b/src/riotwatcher/_apis/team_fight_tactics/urls/LeagueApiUrls.py
@@ -14,3 +14,4 @@ class LeagueApiUrls:
     grandmaster = LeagueEndpoint("/grandmaster")
     by_id = LeagueEndpoint("/leagues/{league_id}")
     master = LeagueEndpoint("/master")
+    rated_ladders = LeagueEndpoint("/rated-ladders/{queue}/top")

--- a/tests/_apis/team_fight_tactics/test_LeagueApi.py
+++ b/tests/_apis/team_fight_tactics/test_LeagueApi.py
@@ -129,3 +129,24 @@ class TestLeagueApi:
         )
 
         assert ret is expected_return
+
+    def test_rated_ladders(self):
+        mock_base_api = MagicMock()
+        expected_return = object()
+        mock_base_api.raw_request.return_value = expected_return
+
+        league = LeagueApi(mock_base_api)
+        region = "afas"
+        queue = "hdhddfd"
+
+        ret = league.rated_ladders(region, queue)
+
+        mock_base_api.raw_request.assert_called_once_with(
+            LeagueApi.__name__,
+            league.rated_ladders.__name__,
+            region,
+            f"https://{region}.api.riotgames.com/tft/league/v1/rated-ladders/{queue}/top",
+            {},
+        )
+
+        assert ret is expected_return

--- a/tests/integration/team_fight_tactics/test_LeagueApi.py
+++ b/tests/integration/team_fight_tactics/test_LeagueApi.py
@@ -81,3 +81,11 @@ class TestLeagueApi:
         tft_context.verify_api_call(
             region, "/tft/league/v1/master", {}, actual_response
         )
+
+    @pytest.mark.parametrize("queue", ["RANKED_TFT_TURBO"])
+    def test_rated_ladders(self, tft_context, region, queue):
+        actual_response = tft_context.watcher.league.rated_ladders(region, queue)
+
+        tft_context.verify_api_call(
+            region, f"/tft/league/v1/rated-ladders/{queue}/top", {}, actual_response
+        )


### PR DESCRIPTION
Add support for rated ladders of TFT league API by TFT season 5, but, Riot API currently only allows RANKED_TFT_TURBO on {queue} so a comment may need to be added.