### PR TITLE
fix typo in matchapiV5 docs header

### DIFF
--- a/docs/riotwatcher/LeagueOfLegends/MatchApiV5.rst
+++ b/docs/riotwatcher/LeagueOfLegends/MatchApiV5.rst
@@ -1,4 +1,4 @@
-MatchApiV4
+MatchApiV5
 ==========
 
 .. py:currentmodule:: riotwatcher


### PR DESCRIPTION
docs header incorrectly states V4 instead of V5