### PR TITLE
Add requests sessions

### DIFF
--- a/src/riotwatcher/_apis/BaseApi.py
+++ b/src/riotwatcher/_apis/BaseApi.py
@@ -7,8 +7,6 @@ class BaseApi:
         self._request_handlers = request_handlers
         self._timeout = timeout
         self._session = session()
-        #self._session.headers.update({"X-Riot-Token": self._api_key})
-        #self._session.mount("https://", adapters.HTTPAdapter(pool_connections=50, pool_maxsize=50))
 
     @property
     def api_key(self):

--- a/src/riotwatcher/_apis/BaseApi.py
+++ b/src/riotwatcher/_apis/BaseApi.py
@@ -1,4 +1,4 @@
-import requests
+from requests import session
 
 
 class BaseApi:
@@ -6,6 +6,9 @@ class BaseApi:
         self._api_key = api_key
         self._request_handlers = request_handlers
         self._timeout = timeout
+        self._session = session()
+        #self._session.headers.update({"X-Riot-Token": self._api_key})
+        #self._session.mount("https://", adapters.HTTPAdapter(pool_connections=50, pool_maxsize=50))
 
     @property
     def api_key(self):
@@ -38,7 +41,7 @@ class BaseApi:
             if self._timeout is not None:
                 extra["timeout"] = self._timeout
 
-            response = requests.get(
+            response = self._session.get(
                 url,
                 params=query_params,
                 headers={"X-Riot-Token": self.api_key},
@@ -73,7 +76,7 @@ class BaseApi:
             if self._timeout is not None:
                 extra["timeout"] = self._timeout
 
-            response = requests.get(url, params=query_params, **extra)
+            response = self._session.get(url, params=query_params, **extra)
 
         if self._request_handlers is not None:
             for handler in self._request_handlers[early_ret_idx:None:-1]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,9 @@
 import datetime
 import json
-import sys
-
-from typing import T
 import unittest.mock as mock
+from typing import T
 
 import pytest
-
 
 real_datetime_class = datetime.datetime
 
@@ -46,7 +43,7 @@ def mock_datetime(monkeypatch):
 def mock_get(monkeypatch) -> mock.MagicMock:
     with monkeypatch.context() as m:
         mock_req = mock.MagicMock()
-        m.setattr("requests.get", mock_req)
+        m.setattr("requests.Session.get", mock_req)
 
         yield mock_req
 


### PR DESCRIPTION
It be more efficient to use [`requests.Session()`](https://docs.python-requests.org/en/master/user/advanced/)?

> The Session object allows you to persist certain parameters across requests. It also persists cookies across all requests made from the Session instance, and will use urllib3’s connection pooling. So if you’re making several requests to the same host, the underlying TCP connection will be reused, which can result in a significant performance increase (see HTTP persistent connection).

Currently using `requests.get()`: https://github.com/pseudonym117/Riot-Watcher/blob/16659b30898dae9f62cee9ddaa8711469f1d0ddd/src/riotwatcher/_apis/BaseApi.py#L41

#187