### PR TITLE
Add Data Dragon versions endpoint. 

### DIFF
--- a/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
+++ b/src/riotwatcher/_apis/league_of_legends/DataDragonApi.py
@@ -44,6 +44,10 @@ class DataDragonApi:
         url, query = DataDragonUrls.versions(region=region)
         return self._base_api.raw_request_static(url, query)
 
+    def versions_all(self):
+        url, query = DataDragonUrls.versions_all()
+        return self._base_api.raw_request_static(url, query)
+
     def _request(self, endpoint: Endpoint, version: str, locale: str):
         url, query = endpoint(version=version, locale=locale if locale else "en_US")
         return self._base_api.raw_request_static(url, query)

--- a/src/riotwatcher/_apis/league_of_legends/urls/DataDragonUrls.py
+++ b/src/riotwatcher/_apis/league_of_legends/urls/DataDragonUrls.py
@@ -25,3 +25,4 @@ class DataDragonUrls:
     runes_reforged = DDragonVersionLocaleEndpoint("/runesReforged.json")
     summoner_spells = DDragonVersionLocaleEndpoint("/summoner.json")
     versions = DataDragonEndpoint("/realms/{region}.json")
+    versions_all = DataDragonEndpoint("/api/versions.json")

--- a/tests/_apis/league_of_legends/test_DataDragonApi.py
+++ b/tests/_apis/league_of_legends/test_DataDragonApi.py
@@ -217,3 +217,17 @@ class TestDataDragonApi:
         )
 
         assert ret is expected_return
+
+    def test_version_all(self):
+        mock_base_api = MagicMock()
+        expected_return = object()
+        mock_base_api.raw_request_static.return_value = expected_return
+
+        static_data = DataDragonApi(mock_base_api)
+
+        ret = static_data.versions_all()
+
+        mock_base_api.raw_request_static.assert_called_once_with(
+            "https://ddragon.leagueoflegends.com/api/versions.json",
+            {},
+        )


### PR DESCRIPTION
This gets a list of all of the valid versions for Data Dragon. https://ddragon.leagueoflegends.com/api/versions.json
Pretty much just creates a `versions_all` method in `DataDragonApi` and the corresponding URL in `DataDragonUrls`. Also creates a test for the endpoint in `test_DataDragonApi`.

AFAIK this functionality wasn't previously implemented in Riot-Watcher.