### PR TITLE
Fix documentation on match id

### DIFF
--- a/src/riotwatcher/_apis/league_of_legends/MatchApiV5.py
+++ b/src/riotwatcher/_apis/league_of_legends/MatchApiV5.py
@@ -25,7 +25,7 @@ class MatchApiV5(NamedEndpoint):
         Get match by match ID
 
         :param string region: The region to execute this request on
-        :param long match_id: The match ID.
+        :param string match_id: The match ID.
 
         :returns: MatchDto
         """


### PR DESCRIPTION
match id should be a string not a long in docs in v5