### PR TITLE
Add support for start param in by_puuid function for MatchApi

### DIFF
--- a/src/riotwatcher/_apis/team_fight_tactics/MatchApi.py
+++ b/src/riotwatcher/_apis/team_fight_tactics/MatchApi.py
@@ -19,15 +19,15 @@ class MatchApi(NamedEndpoint):
         super().__init__(base_api, self.__class__.__name__)
 
     @remap_region_to_platform(1)
-    def by_puuid(self, region: str, puuid: str, start: int = 0, count: int = 20):
+    def by_puuid(self, region: str, puuid: str, count: int = 20, start: int = 0):
         """
         Get a list of match ids by PUUID.
 
         :param string region:   The region to execute this request on
         :param string puuid:    The puuid.
-        :param int start:       Defaults to 0. Start index.
         :param int count:       Defaults to 20. Valid values: 0 to 100. Number of
                                 match ids to return.
+        :param int start:       Defaults to 0. Start index.
 
         :returns: List[string]
         """

--- a/src/riotwatcher/_apis/team_fight_tactics/MatchApi.py
+++ b/src/riotwatcher/_apis/team_fight_tactics/MatchApi.py
@@ -19,9 +19,15 @@ class MatchApi(NamedEndpoint):
         super().__init__(base_api, self.__class__.__name__)
 
     @remap_region_to_platform(1)
-    def by_puuid(self, region: str, puuid: str, count: int = 20):
+    def by_puuid(self, region: str, puuid: str, start: int = 0, count: int = 20):
         """
         Get a list of match ids by PUUID.
+
+        :param string region:   The region to execute this request on
+        :param string puuid:    The puuid.
+        :param int start:       Defaults to 0. Start index.
+        :param int count:       Defaults to 20. Valid values: 0 to 100. Number of
+                                match ids to return.
 
         :returns: List[string]
         """
@@ -30,6 +36,7 @@ class MatchApi(NamedEndpoint):
             region,
             MatchApiUrls.by_puuid,
             puuid=puuid,
+            start=start,
             count=count,
         )
 
@@ -37,6 +44,9 @@ class MatchApi(NamedEndpoint):
     def by_id(self, region: str, match_id: str):
         """
         Get a match by match id.
+
+        :param string region:   The region to execute this request on
+        :param string match_id: The match ID.
 
         :returns: MatchDto
         """

--- a/src/riotwatcher/_apis/team_fight_tactics/urls/MatchApiUrls.py
+++ b/src/riotwatcher/_apis/team_fight_tactics/urls/MatchApiUrls.py
@@ -8,5 +8,5 @@ class MatchEndpoint(TftEndpoint):
 
 
 class MatchApiUrls:
-    by_puuid = MatchEndpoint("/by-puuid/{puuid}/ids", count=int)
+    by_puuid = MatchEndpoint("/by-puuid/{puuid}/ids", start=int, count=int)
     by_id = MatchEndpoint("/{match_id}")

--- a/tests/_apis/team_fight_tactics/test_MatchApi.py
+++ b/tests/_apis/team_fight_tactics/test_MatchApi.py
@@ -21,7 +21,7 @@ def mock_match_api():
 @pytest.mark.tft
 @pytest.mark.unit
 class TestMatchApi:
-    def test_by_puuid(self, mock_match_api):
+    def test_by_puuid_defaults(self, mock_match_api):
         region = "afas"
         puuid = "15462-54321"
 
@@ -32,7 +32,24 @@ class TestMatchApi:
             mock_match_api.api.by_puuid.__name__,
             region,
             f"https://{region}.api.riotgames.com/tft/match/v1/matches/by-puuid/{puuid}/ids",
-            {"count": 20},
+            {"count": 20, "start": 0},
+        )
+
+        assert ret is mock_match_api.expected_return
+
+    def test_by_puuid_takes_args(self, mock_match_api):
+        region = "afas"
+        puuid = "15462-54321"
+        start, count = 50, 100
+
+        ret = mock_match_api.api.by_puuid(region, puuid, count, start)
+
+        mock_match_api.base_api.raw_request.assert_called_once_with(
+            MatchApi.__name__,
+            mock_match_api.api.by_puuid.__name__,
+            region,
+            f"https://{region}.api.riotgames.com/tft/match/v1/matches/by-puuid/{puuid}/ids",
+            {"count": count, "start": start},
         )
 
         assert ret is mock_match_api.expected_return
@@ -47,7 +64,7 @@ class TestMatchApi:
             mock_match_api.api.by_puuid.__name__,
             region_remap.to,
             f"https://{region_remap.to}.api.riotgames.com/tft/match/v1/matches/by-puuid/{puuid}/ids",
-            {"count": 20},
+            {"count": 20, "start": 0},
         )
 
     def test_by_id(self, mock_match_api):

--- a/tests/integration/team_fight_tactics/test_MatchApi.py
+++ b/tests/integration/team_fight_tactics/test_MatchApi.py
@@ -9,13 +9,16 @@ import pytest
 class TestMatchApi:
     @pytest.mark.parametrize("puuid", ["12345", "99999999999999999999"])
     @pytest.mark.parametrize("count", [5, 50, 200])
-    def test_by_puuid(self, tft_context, region, puuid, count):
-        actual_response = tft_context.watcher.match.by_puuid(region, puuid, count=count)
+    @pytest.mark.parametrize("start", [0, 10, 300])
+    def test_by_puuid(self, tft_context, region, puuid, count, start):
+        actual_response = tft_context.watcher.match.by_puuid(
+            region, puuid, count=count, start=start
+        )
 
         tft_context.verify_api_call(
             region,
             f"/tft/match/v1/matches/by-puuid/{puuid}/ids",
-            {"count": count},
+            {"count": count, "start": start},
             actual_response,
         )
 
@@ -40,7 +43,7 @@ class TestMatchApiRemapping:
         tft_context.verify_api_call(
             region_remap.to,
             f"/tft/match/v1/matches/by-puuid/{puuid}/ids",
-            {"count": 20},
+            {"count": 20, "start": 0},
             actual_response,
         )
 


### PR DESCRIPTION
I want to be able to get more that 100 TFT matches, as I'm sure many people do. This isn't possible without changing the start param, so I added it. I threw in some docs while I was at it.