### PR TITLE
Fix entries endpoint for tft

### DIFF
--- a/src/riotwatcher/_apis/team_fight_tactics/urls/LeagueApiUrls.py
+++ b/src/riotwatcher/_apis/team_fight_tactics/urls/LeagueApiUrls.py
@@ -10,7 +10,7 @@ class LeagueEndpoint(TftEndpoint):
 class LeagueApiUrls:
     challenger = LeagueEndpoint("/challenger")
     by_summoner = LeagueEndpoint("/entries/by-summoner/{encrypted_summoner_id}")
-    entries = LeagueEndpoint("/entries/{tier}/{division}", page=int)
+    entries = LeagueEndpoint("/entries/{division}/{tier}", page=int)
     grandmaster = LeagueEndpoint("/grandmaster")
     by_id = LeagueEndpoint("/leagues/{league_id}")
     master = LeagueEndpoint("/master")


### PR DESCRIPTION
Documentation shows that the order is /{tier}/{division}. However, this returns a 400. After analyzing the request url in the  developer site the correct one shows as /{division}/{tier}