### PR TITLE
fix: add missing startTime and endTime parameters to TFT MatchApi

### DIFF
--- a/src/riotwatcher/_apis/team_fight_tactics/MatchApi.py
+++ b/src/riotwatcher/_apis/team_fight_tactics/MatchApi.py
@@ -2,6 +2,8 @@ from .. import BaseApi, NamedEndpoint
 from ..helpers import remap_region_to_platform
 from .urls import MatchApiUrls
 
+from typing import Optional
+
 
 class MatchApi(NamedEndpoint):
     """
@@ -19,7 +21,15 @@ class MatchApi(NamedEndpoint):
         super().__init__(base_api, self.__class__.__name__)
 
     @remap_region_to_platform(1)
-    def by_puuid(self, region: str, puuid: str, count: int = 20, start: int = 0):
+    def by_puuid(
+        self,
+        region: str,
+        puuid: str,
+        count: int = 20,
+        start: int = 0,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ):
         """
         Get a list of match ids by PUUID.
 
@@ -28,16 +38,28 @@ class MatchApi(NamedEndpoint):
         :param int count:       Defaults to 20. Valid values: 0 to 100. Number of
                                 match ids to return.
         :param int start:       Defaults to 0. Start index.
+        :param int start_time:  Epoch timestamp in seconds.
+        :param int end_time:    Epoch timestamp in seconds.
 
         :returns: List[string]
         """
+        args = {
+            "count": count,
+            "start": start,
+        }
+
+        if start_time:
+            args["startTime"] = start_time
+
+        if end_time:
+            args["endTime"] = end_time
+
         return self._request_endpoint(
             self.by_puuid.__name__,
             region,
             MatchApiUrls.by_puuid,
             puuid=puuid,
-            start=start,
-            count=count,
+            **args,
         )
 
     @remap_region_to_platform(1)

--- a/tests/_apis/team_fight_tactics/test_MatchApi.py
+++ b/tests/_apis/team_fight_tactics/test_MatchApi.py
@@ -41,15 +41,23 @@ class TestMatchApi:
         region = "afas"
         puuid = "15462-54321"
         start, count = 50, 100
+        start_time, end_time = 1683990000, 1683991032
 
-        ret = mock_match_api.api.by_puuid(region, puuid, count, start)
+        ret = mock_match_api.api.by_puuid(
+            region,
+            puuid,
+            count,
+            start,
+            start_time,
+            end_time,
+        )
 
         mock_match_api.base_api.raw_request.assert_called_once_with(
             MatchApi.__name__,
             mock_match_api.api.by_puuid.__name__,
             region,
             f"https://{region}.api.riotgames.com/tft/match/v1/matches/by-puuid/{puuid}/ids",
-            {"count": count, "start": start},
+            {"count": count, "start": start, "startTime": start_time, "endTime": end_time},
         )
 
         assert ret is mock_match_api.expected_return


### PR DESCRIPTION
These two parameters from Riot API were missing in the library.