### PR TITLE
riot games updated the queue parameter to queueId

### DIFF
--- a/src/riotwatcher/_apis/league_of_legends/MatchApiV5.py
+++ b/src/riotwatcher/_apis/league_of_legends/MatchApiV5.py
@@ -77,7 +77,7 @@ class MatchApiV5(NamedEndpoint):
             puuid=puuid,
             start=start,
             count=count,
-            queue=queue,
+            queueId=queue,
             type=type,
             startTime=start_time,
             endTime=end_time,


### PR DESCRIPTION
They didn't update the documents, it took me time to solve the error :D